### PR TITLE
Squash apt-get commands into one to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM ubuntu:15.10
 MAINTAINER Zalando SE
 
-RUN apt-get update && apt-get dist-upgrade -y
-RUN apt-get install --no-install-recommends -y language-pack-en ca-certificates curl lsb-release
-RUN apt-get purge -y krb5-locales
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends \
+          language-pack-en \
+          ca-certificates \
+          curl \
+          lsb-release \
+      && apt-get purge -y \
+          krb5-locales \
+      && apt-get clean -y \
+      && apt-get autoremove -y \
+      && rm -rf /tmp/* /var/tmp/* \
+      && rm -rf /var/lib/apt/lists/*
 
 # set locale
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
We can save about 22 megabytes by reducing the installation and cleanup commands into one.
- before: 241.6 MB
- after: 219.5 MB
